### PR TITLE
Fix Java keywords

### DIFF
--- a/src/de/dreamlab/dash/KeywordLookup.java
+++ b/src/de/dreamlab/dash/KeywordLookup.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 
 public class KeywordLookup {
     private static String CONFIG_KEYWORDS = "DASH_PLUGIN_KEYWORDS";
-    private static String DEFAULT_KEYWORDS = "ActionScript=actionscript;C++=cpp;CoffeeScriptcoffee;Perl=perl;CSS=css;Erlang=erlang;Haskell=haskell;HTML=html;JAVA=java;CLASS=java;JavaScript=javascript;LESS=less;PHP=php;SASS=sass;Ruby=ruby";
+    private static String DEFAULT_KEYWORDS = "ActionScript=actionscript;C++=cpp;CoffeeScript=coffee;Perl=perl;CSS=css;Erlang=erlang;Haskell=haskell;HTML=html;JAVA=java7;CLASS=java7;JavaScript=javascript;LESS=less;PHP=php;SASS=sass;Ruby=ruby";
 
     private HashMap<String, String> typeMap;
     private HashMap<String, String> extensionMap;


### PR DESCRIPTION
The default keyword for Java is either java6 or java7.

Also CoffeeScript appeared like "CoffeeScriptcoffee". I think it should be "CoffeeScript=coffee".
