### PR TITLE
Fixed link

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -6,8 +6,7 @@
 
   <description><![CDATA[
 <p>A smart and simple plugin that provides keyboard shortcut access for Dash, Velocity or Zeal in IntelliJ IDEA, RubyMine, WebStorm, PhpStorm, PyCharm and Android Studio.</p>
-<p>&nbsp;</p>
-<p><a href="http://flattr.com/thing/2558535/gdelmasIntelliJDashPlugin-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" /></a></p>
+<p><a href="http://flattr.com/thing/2558535/gdelmasIntelliJDashPlugin-on-GitHub" target="_blank">http://flattr.com/thing/2558535/gdelmasIntelliJDashPlugin-on-GitHub</a></p>
 
 <p><h2><b>Usage</b></h2></p>
 <p>The default <b>shortcut</b> assigned to search is <b>Cmd-Shift-D</b> (Mac OS X) or <b>Ctrl-Shift-D</b> (Windows, Linux).</p>


### PR DESCRIPTION
Hi, I found that `img` tag is broken on IntelliJ Plugin screen, like below.
So, I fixed to only `a` tag.

I can't find official document why `img` tag is rejected in `description` area, sorry.

![intellij_dash_plugin](https://cloud.githubusercontent.com/assets/1573290/8928545/1fd6519c-355a-11e5-9127-39398577f56c.png)

Thank you so much.