### PR TITLE
Add correct angular keyword for Zeal

### DIFF
--- a/src/de/dreamlab/dash/KeywordLookup.java
+++ b/src/de/dreamlab/dash/KeywordLookup.java
@@ -33,7 +33,7 @@ public class KeywordLookup {
         setLanguage("CoffeeScript", "coffee", "javascript", "jquery", "jqueryui", "jquerym", "backbone", "marionette", "meteor", "sproutcore", "moo", "prototype", "bootstrap", "foundation", "lodash", "underscore", "ember", "sencha", "extjs", "titanium", "knockout", "zepto", "yui", "d3", "dojo", "nodejs", "express", "grunt", "mongoose", "moment", "require", "awsjs", "jasmine", "sinon", "chai", "cordova", "phonegap"); // not IntelliJ
 
         setLanguage("JavaScript", (Object[])FileTypeSpecificKeyword.createList(
-                new String[]{"javascript", "jquery", "jqueryui", "jquerym", "backbone", "marionette", "meteor", "sproutcore", "moo", "prototype", "bootstrap", "foundation", "lodash", "underscore", "ember", "sencha", "extjs", "titanium", "knockout", "zepto", "yui", "d3", "dojo", "nodejs", "express", "grunt", "mongoose", "moment", "require", "awsjs", "jasmine", "sinon", "chai", "cordova", "phonegap", "angularjs", "angularts"},
+                new String[]{"javascript", "jquery", "jqueryui", "jquerym", "backbone", "marionette", "meteor", "sproutcore", "moo", "prototype", "bootstrap", "foundation", "lodash", "underscore", "ember", "sencha", "extjs", "titanium", "knockout", "zepto", "yui", "d3", "dojo", "nodejs", "express", "grunt", "mongoose", "moment", "require", "awsjs", "jasmine", "sinon", "chai", "cordova", "phonegap", "angularjs", "angularts", "angular"},
                 "ActionScript", new String[]{"actionscript"})
         );
 


### PR DESCRIPTION
In the current version of Zeal (0.5.0), the correct keyword for the angular docs is just angular, not angularts.