### PR TITLE
Added language support mapping for Dart -> Flutter docs.

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
   <id>com.paperetto.dash</id>
   <name>Dash</name>
-  <version>3.3</version>
+  <version>3.3.1</version>
   <vendor url="https://github.com/gdelmas/IntelliJDashPlugin">Gerard Delmàs</vendor>
 
   <description><![CDATA[
@@ -29,6 +29,8 @@
 
   <change-notes><![CDATA[
 <pre>
+3.3.1
+    - Extended language support for Dart to include Flutter.
 3.3
     - Added non-smart "Search all Documentation" option
     - Java 9 SDK detection

--- a/src/de/dreamlab/dash/KeywordLookup.java
+++ b/src/de/dreamlab/dash/KeywordLookup.java
@@ -49,7 +49,7 @@ public class KeywordLookup {
         final IKeyword playjavaKeyword = new ExcludeSdkTypeKeyword("playjava", "Android SDK");
         final IKeyword springKeyword = new ExcludeSdkTypeKeyword("spring", "Android SDK");
 
-        setLanguage("Dart", "dartlang", "polymerdart", "angulardart"); // WebStorm
+        setLanguage("Dart", "dartlang", "polymerdart", "angulardart", "flutter"); // WebStorm
         setLanguage("DjangoTemplate", "django"); // PyCharm
         setLanguage("Groovy", "groovy"); // IntelliJ
         setLanguage("Jade", "jade"); // WebStorm


### PR DESCRIPTION
Flutter (<http://docs.flutter.io>) now has docset support, but activating Dash on Flutter APIs with the plugin doesn't work because flutter is not one of the docsets searched in Dart mode.

I bumped the version number preemptively, but I'd be happy to revert that part of the change if desired.